### PR TITLE
Fixed conversion of ftFloat, ftFMTBcd, ftBCD, Single types

### DIFF
--- a/src/DataSetConverter4D.Impl.pas
+++ b/src/DataSetConverter4D.Impl.pas
@@ -141,10 +141,12 @@ var
   bft: TBooleanFieldType;
   ms: TMemoryStream;
   ss: TStringStream;
+  fs: TFormatSettings;
 begin
   Result := nil;
   if Assigned(dataSet) and (not dataSet.IsEmpty) then
   begin
+    fs.DecimalSeparator := '.';
     Result := TJSONObject.Create;
     for i := 0 to Pred(dataSet.FieldCount) do
     begin
@@ -172,7 +174,7 @@ begin
           TFieldType.ftLargeint:
             Result.AddPair(key, TJSONNumber.Create(dataSet.Fields[i].AsLargeInt));
           TFieldType.ftSingle, TFieldType.ftFloat:
-            Result.AddPair(key, TJSONNumber.Create(dataSet.Fields[i].AsFloat));
+            Result.AddPair(key, TJSONNumber.Create(FloatToStr(dataSet.Fields[i].AsFloat, fs)));
           ftString, ftWideString, ftMemo, ftWideMemo:
             begin
               if not dataSet.Fields[i].IsNull then
@@ -214,7 +216,7 @@ begin
           TFieldType.ftFMTBcd, TFieldType.ftBCD:
             begin
               if not dataSet.Fields[i].IsNull then
-                Result.AddPair(key, TJSONNumber.Create(BcdToDouble(dataSet.Fields[i].AsBcd)))
+                Result.AddPair(key, TJSONNumber.Create(BcdToStr(dataSet.Fields[i].AsBcd, fs)))
               else
                 Result.AddPair(key, TJSONNull.Create);
             end;
@@ -434,7 +436,7 @@ begin
             if jv is TJSONNull then
               field.Clear
             else
-              field.AsFloat := StrToFloat(jv.Value);
+              field.AsFloat := jv.GetValue<Double>;
           end;
         ftString, ftWideString, ftMemo, ftWideMemo:
           begin

--- a/src/DataSetConverter4D.Impl.pas
+++ b/src/DataSetConverter4D.Impl.pas
@@ -434,7 +434,8 @@ begin
             if jv is TJSONNull then
               field.Clear
             else
-              field.AsFloat := StrToFloat(jv.Value);
+//              field.AsFloat := StrToFloat(jv.Value);
+              field.AsFloat := jv.GetValue<Double>;
           end;
         ftString, ftWideString, ftMemo, ftWideMemo:
           begin

--- a/src/DataSetConverter4D.Impl.pas
+++ b/src/DataSetConverter4D.Impl.pas
@@ -141,10 +141,8 @@ var
   bft: TBooleanFieldType;
   ms: TMemoryStream;
   ss: TStringStream;
-  fs: TFormatSettings;
 begin
   Result := nil;
-  fs.DecimalSeparator := '.';
   if Assigned(dataSet) and (not dataSet.IsEmpty) then
   begin
     Result := TJSONObject.Create;
@@ -174,7 +172,7 @@ begin
           TFieldType.ftLargeint:
             Result.AddPair(key, TJSONNumber.Create(dataSet.Fields[i].AsLargeInt));
           TFieldType.ftSingle, TFieldType.ftFloat:
-            Result.AddPair(key, TJSONNumber.Create(FloatToStr(dataSet.Fields[i].AsFloat, fs)));
+            Result.AddPair(key, TJSONNumber.Create(dataSet.Fields[i].AsFloat));
           ftString, ftWideString, ftMemo, ftWideMemo:
             begin
               if not dataSet.Fields[i].IsNull then
@@ -216,7 +214,7 @@ begin
           TFieldType.ftFMTBcd, TFieldType.ftBCD:
             begin
               if not dataSet.Fields[i].IsNull then
-                Result.AddPair(key, TJSONNumber.Create(BcdToStr(dataSet.Fields[i].AsBcd, fs)))
+                Result.AddPair(key, TJSONNumber.Create(BcdToDouble(dataSet.Fields[i].AsBcd)))
               else
                 Result.AddPair(key, TJSONNull.Create);
             end;
@@ -436,8 +434,7 @@ begin
             if jv is TJSONNull then
               field.Clear
             else
-//              field.AsFloat := StrToFloat(jv.Value);
-              field.AsFloat := jv.GetValue<Double>;
+              field.AsFloat := StrToFloat(jv.Value);
           end;
         ftString, ftWideString, ftMemo, ftWideMemo:
           begin

--- a/src/DataSetConverter4D.Impl.pas
+++ b/src/DataSetConverter4D.Impl.pas
@@ -434,8 +434,7 @@ begin
             if jv is TJSONNull then
               field.Clear
             else
-//              field.AsFloat := StrToFloat(jv.Value);
-              field.AsFloat := jv.GetValue<Double>;
+              field.AsFloat := StrToFloat(jv.Value);
           end;
         ftString, ftWideString, ftMemo, ftWideMemo:
           begin

--- a/src/DataSetConverter4D.Impl.pas
+++ b/src/DataSetConverter4D.Impl.pas
@@ -141,8 +141,10 @@ var
   bft: TBooleanFieldType;
   ms: TMemoryStream;
   ss: TStringStream;
+  fs: TFormatSettings;
 begin
   Result := nil;
+  fs.DecimalSeparator := '.';
   if Assigned(dataSet) and (not dataSet.IsEmpty) then
   begin
     Result := TJSONObject.Create;
@@ -172,7 +174,7 @@ begin
           TFieldType.ftLargeint:
             Result.AddPair(key, TJSONNumber.Create(dataSet.Fields[i].AsLargeInt));
           TFieldType.ftSingle, TFieldType.ftFloat:
-            Result.AddPair(key, TJSONNumber.Create(dataSet.Fields[i].AsFloat));
+            Result.AddPair(key, TJSONNumber.Create(FloatToStr(dataSet.Fields[i].AsFloat, fs)));
           ftString, ftWideString, ftMemo, ftWideMemo:
             begin
               if not dataSet.Fields[i].IsNull then
@@ -214,7 +216,7 @@ begin
           TFieldType.ftFMTBcd, TFieldType.ftBCD:
             begin
               if not dataSet.Fields[i].IsNull then
-                Result.AddPair(key, TJSONNumber.Create(BcdToDouble(dataSet.Fields[i].AsBcd)))
+                Result.AddPair(key, TJSONNumber.Create(BcdToStr(dataSet.Fields[i].AsBcd, fs)))
               else
                 Result.AddPair(key, TJSONNull.Create);
             end;
@@ -434,7 +436,8 @@ begin
             if jv is TJSONNull then
               field.Clear
             else
-              field.AsFloat := StrToFloat(jv.Value);
+//              field.AsFloat := StrToFloat(jv.Value);
+              field.AsFloat := jv.GetValue<Double>;
           end;
         ftString, ftWideString, ftMemo, ftWideMemo:
           begin

--- a/unittest/DataSetConverter4D.UnitTest.pas
+++ b/unittest/DataSetConverter4D.UnitTest.pas
@@ -38,6 +38,7 @@ type
     procedure TestConvertStructureToJSON;
     procedure TestConvertJSONToStructure;
     procedure TestConvertDataSetToJSONBasicInvisibleFields;
+    procedure TestConvertJsonToFDMemTable_PR_32;
   end;
 
 implementation
@@ -231,7 +232,7 @@ const
     '{"Id":1,"Description":"Sales 1","Date":"2014-01-22","Time":"14:03:03",' +
     '"Customers":{"Id":2,"Name":"Customers 2","Birth":"2014-01-22 14:05:03"},' +
     '"Products":[{"Id":1,"Description":"Product 1","Value":100},' +
-    '{"Id":2,"Description":"Product 2","Value":200}]}';
+    '{"Id":2,"Description":"Product 2","Value":200.123456789}]}';
 var
   jo: TJSONObject;
 begin
@@ -256,7 +257,7 @@ begin
   fCdsProducts.Append;
   fCdsProducts.FieldByName('Id').AsInteger := 2;
   fCdsProducts.FieldByName('Description').AsString := 'Product 2';
-  fCdsProducts.FieldByName('Value').AsFloat := 200;
+  fCdsProducts.FieldByName('Value').AsFloat := 200.123456789;
   fCdsProducts.Post;
 
   fCdsSales.Post;
@@ -551,6 +552,74 @@ begin
       jo.Free;
     end;
   finally
+    cds.Free;
+  end;
+end;
+
+procedure TTestsDataSetConverter.TestConvertJsonToFDMemTable_PR_32;
+const
+  JSON =
+    '{' +
+      '"Structure": [' +
+        '{' +
+          '"FieldName": "Id",' +
+          '"DataType": "ftInteger",' +
+          '"Size": 0' +
+        '},{' +
+          '"FieldName": "Description",' +
+          '"DataType": "ftString",' +
+          '"Size": 100' +
+        '},{' +
+          '"FieldName": "Value",' +
+          '"DataType": "ftBCD",' +
+          '"Size": 2' +
+        '}' +
+      '],' +
+      '"Products": [' +
+        '{' +
+          '"Id": 1,' +
+          '"Description": "Product 1",' +
+          '"Value": 100.12' +
+        '},{' +
+          '"Id": 2,' +
+          '"Description": "Product 2",' +
+          '"Value": 200' +
+        '}' +
+      ']' +
+    '}';
+var
+  jo: TJSONObject;
+  cds: TClientDataSet;
+begin
+  cds := TClientDataSet.Create(nil);
+  try
+    jo := TJSONObject.ParseJSONValue(TEncoding.UTF8.GetBytes(JSON), 0) as TJSONObject;
+    try
+      cds.Close;
+      cds.Fields.Clear;
+      TConverter.New.JSON(
+        jo.Values['Structure'].AsType<TJSONArray>).ToStructure(cds);
+      cds.CreateDataSet;
+      cds.Open;
+      CheckException(
+        procedure
+        begin
+          TConverter.New.JSON(jo.Values['Products'].AsType<TJSONArray>).ToDataSet(cds)
+        end, nil);
+      cds.First;
+      while not cds.Eof do
+      begin
+        if (cds.RecNo = 1) then
+          CheckEquals(100.12, cds.FieldByName('Value').AsFloat, 2)
+        else if (cds.RecNo = 2) then
+          CheckEquals(200, cds.FieldByName('Value').AsFloat);
+        cds.Next;
+      end;
+    finally
+      jo.Free;
+    end;
+  finally
+    cds.Close;
     cds.Free;
   end;
 end;

--- a/unittest/DataSetConverter4D.UnitTest.pas
+++ b/unittest/DataSetConverter4D.UnitTest.pas
@@ -38,7 +38,6 @@ type
     procedure TestConvertStructureToJSON;
     procedure TestConvertJSONToStructure;
     procedure TestConvertDataSetToJSONBasicInvisibleFields;
-    procedure TestConvertJsonToFDMemTable_PR_32;
   end;
 
 implementation
@@ -232,7 +231,7 @@ const
     '{"Id":1,"Description":"Sales 1","Date":"2014-01-22","Time":"14:03:03",' +
     '"Customers":{"Id":2,"Name":"Customers 2","Birth":"2014-01-22 14:05:03"},' +
     '"Products":[{"Id":1,"Description":"Product 1","Value":100},' +
-    '{"Id":2,"Description":"Product 2","Value":200.123456789}]}';
+    '{"Id":2,"Description":"Product 2","Value":200}]}';
 var
   jo: TJSONObject;
 begin
@@ -257,7 +256,7 @@ begin
   fCdsProducts.Append;
   fCdsProducts.FieldByName('Id').AsInteger := 2;
   fCdsProducts.FieldByName('Description').AsString := 'Product 2';
-  fCdsProducts.FieldByName('Value').AsFloat := 200.123456789;
+  fCdsProducts.FieldByName('Value').AsFloat := 200;
   fCdsProducts.Post;
 
   fCdsSales.Post;
@@ -552,74 +551,6 @@ begin
       jo.Free;
     end;
   finally
-    cds.Free;
-  end;
-end;
-
-procedure TTestsDataSetConverter.TestConvertJsonToFDMemTable_PR_32;
-const
-  JSON =
-    '{' +
-      '"Structure": [' +
-        '{' +
-          '"FieldName": "Id",' +
-          '"DataType": "ftInteger",' +
-          '"Size": 0' +
-        '},{' +
-          '"FieldName": "Description",' +
-          '"DataType": "ftString",' +
-          '"Size": 100' +
-        '},{' +
-          '"FieldName": "Value",' +
-          '"DataType": "ftBCD",' +
-          '"Size": 2' +
-        '}' +
-      '],' +
-      '"Products": [' +
-        '{' +
-          '"Id": 1,' +
-          '"Description": "Product 1",' +
-          '"Value": 100.12' +
-        '},{' +
-          '"Id": 2,' +
-          '"Description": "Product 2",' +
-          '"Value": 200' +
-        '}' +
-      ']' +
-    '}';
-var
-  jo: TJSONObject;
-  cds: TClientDataSet;
-begin
-  cds := TClientDataSet.Create(nil);
-  try
-    jo := TJSONObject.ParseJSONValue(TEncoding.UTF8.GetBytes(JSON), 0) as TJSONObject;
-    try
-      cds.Close;
-      cds.Fields.Clear;
-      TConverter.New.JSON(
-        jo.Values['Structure'].AsType<TJSONArray>).ToStructure(cds);
-      cds.CreateDataSet;
-      cds.Open;
-      CheckException(
-        procedure
-        begin
-          TConverter.New.JSON(jo.Values['Products'].AsType<TJSONArray>).ToDataSet(cds)
-        end, nil);
-      cds.First;
-      while not cds.Eof do
-      begin
-        if (cds.RecNo = 1) then
-          CheckEquals(100.12, cds.FieldByName('Value').AsFloat, 2)
-        else if (cds.RecNo = 2) then
-          CheckEquals(200, cds.FieldByName('Value').AsFloat);
-        cds.Next;
-      end;
-    finally
-      jo.Free;
-    end;
-  finally
-    cds.Close;
     cds.Free;
   end;
 end;


### PR DESCRIPTION
Example: 
`TConverter.New.JSON(lJson.Values['data'].AsType<TJSONArray>).ToDataSet(FDMemTable1);`

raises an exception at the line:
`field.AsFloat := StrToFloat(jv.Value);`

changed to:
`field.AsFloat := jv.GetValue<Double>;`

